### PR TITLE
Add fiorix/go-diameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A curated list of telco resources and projects.
 - [Pycrate](https://github.com/P1sec/pycrate) - the successor of the libmich library that is used to encode and decode data structures, including ASN.1 used in cellular protocol.
 - [OGSLib](https://github.com/open5gs/ogslib) - state machine and utilities functions for NextEPC and Open5gs
 - [DIAGLibrary](https://github.com/sanjaywave/DiagLibrary) -  a JNI library that implement a DIAG protocol parser under C code to be used under Android or Linux.
+- [go-diameter](https://github.com/fiorix/go-diameter) - Package go-diameter is an implementation of the Diameter Base Protocol RFC 6733 and a stack for the Go programming language.
 
 ## Infrastructure
 


### PR DESCRIPTION
Added [go-diameter](https://github.com/fiorix/go-diameter) which is performant and extensible Diameter protocol stack implemented in Golang by @fiorix.
