### PR TITLE
add Telcometer

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Resources
 - [Eclipse Titan TTCN3](https://projects.eclipse.org/projects/tools.titan) - Eclipse Titan is a TTCN-3 compilation and execution environment with an  Eclipse-based IDE.
 - [TTCN3vscode](https://github.com/nokia/vscode-ttcn3) - TTCN-3 vs code plugin
 - [ixia-c](https://github.com/open-traffic-generator/ixia-c) - Ixia-c is a modern, powerful and API-driven traffic generator designed to cater to the needs of hyperscalers, network hardware vendors and hobbyists alike.
+- [Telcometer](https://github.com/itsMohammadHeidari/Telcometer) - Diameter Credit-Control Application Load Testing script powered by [Grafana K6](https://github.com/grafana/k6)
 
 ## Security
 


### PR DESCRIPTION
[Telcometer](https://github.com/itsMohammadHeidari/Telcometer) is a load testing script for Diameter Credit-Control Applications, powered by [Grafana K6](https://github.com/grafana/k6). It is designed for testing the load on online charging systems.