### PR TITLE
Add PikaSim - Privacy-first eSIM Reseller API

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ Companies offering products/services around open source telco tech:
 - [open-cells](https://open-cells.com) - 4G and 5G full open source testbed solutions.
 - [5ber eSIM](http://esim.5ber.com) - Physical SIM card that stores up to 15 eSIM profiles (GSMA compliant).
 - [esim.me](https://esim.me) - Physical SIM + app combo for loading up to 15 eSIM profiles.
+- [PikaSim](https://pikasim.com/reseller) - Privacy-first eSIM Reseller API. Purchase travel eSIMs for 190+ countries programmatically with webhooks and no customer data required.
 
 ---
 


### PR DESCRIPTION
## What is PikaSim?

[PikaSim](https://pikasim.com) is a privacy-first eSIM provider with a Reseller API for purchasing travel eSIMs programmatically.

## Why Commercial section?

PikaSim fits alongside other commercial eSIM offerings like 5ber eSIM and esim.me, offering:

- **eSIM Reseller API** - Purchase eSIMs programmatically
- **190+ countries** coverage
- **Webhooks** for async provisioning notifications
- **Privacy-first** - No customer data required
- **No signup needed** - Create wallet and start immediately

## Links

- Website: https://pikasim.com
- Reseller API: https://pikasim.com/reseller
- API Documentation: https://pikasim.com/reseller/api-docs