### PR TITLE
Add iot.cards Web Tools to SIM/USIM Tools & Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ For research and debugging:
 - [onomondo-softsim-cli](https://github.com/onomondo/onomondo-softsim-cli) `[2026-06]` - CLI tool to provision Onomondo SoftSIM profiles.
 - [mcc-mnc-itu](https://github.com/onomondo/mcc-mnc-itu) `[2025-07]` - Library to look up MCC/MNC operator information from the official ITU dataset.
 - [simshell](https://github.com/kurbatoff/simshell) `[2025-10]` - Interactive shell for SIM, GlobalPlatform and JavaCard VM operations over APDU.
+- [iot.cards Web Tools](https://iot.cards/en/resources/tools) - Browser-side utilities for SIM, cellular and eSIM work, including ICCID/IMSI/IMEI/MSISDN decoders, a CSQ/RSRP signal interpreter, an EARFCN/band lookup, AT-command and APN helpers, and a GSMA SGP.22 activation-code parser. Runs entirely client-side with no sign-up.
 
 ### eSIM / eUICC
 


### PR DESCRIPTION
Adds one entry under SIM/USIM Tools & Hardware for iot.cards Web Tools, a set of free, browser-side SIM/cellular utilities (ICCID/IMSI/IMEI/MSISDN decoders, CSQ/RSRP/RSRQ/SINR signal interpreter, AT-command reference with CGDCONT builder, APN config generator, LTE/NB-IoT/LTE-M band<->EARFCN explorer, and a GSMA SGP.22 eSIM activation-code parser). Everything runs client-side (no sign-up, nothing sent to a server). Fits "tools for analyzing mobile networks" per the contributing guidelines.