### PR TITLE
Add mmt-studio-5g6g (MMT Studio Core) to Core Network 5G list

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ For research and debugging:
 ### 5G
 
 - [Open5GS](https://open5gs.org) `[2025-12]` - 5G, R14 4G EPC core with independent MME, HSS, SGW, PGW, PCRF, UPF, SMF, NRF functions. Follow-up of NextEPC. [github](https://github.com/open5gs)
+- [mmt-studio-5g6g](https://github.com/Makemytechnology/mmt-studio-5g6g) `[2026-07]` - Open-source 5G SA core (MMT Studio Core) built on Open5GS, for private 5G lab and testbed deployments.
 - [OAI 5GCN](https://gitlab.eurecom.fr/oai/cn5g) - OAI(Open Air Interface) was initially developed by EURECOM, provides a 3GPP-Compliant 5G SA Core Network.
 - ⚠️ [travelping-vpp](https://github.com/travelping/vpp) `[2021-01]` - UPF plugins implements a GTP-U user plane based on 3GPP TS 23.214 and 3GPP TS 29.244 Release 15, adding UPF as a plugin to VPP.
 - ⚠️ [IITB 5G SBA PoC](https://github.com/iithnewslab/SBA-gRPC-5G) `[2019-08]` - Prototyping and Load Balancing the Service Based Architecture of 5G Core using NFV - [research paper from IITB](https://github.com/iithnewslab/SBA-gRPC-5G/blob/master/Presentation_Netsoft19_gRPC_5G.pdf)


### PR DESCRIPTION
Adds mmt-studio-5g6g to the Core Network -> 5G list, directly below Open5GS.

Project: https://github.com/Makemytechnology/mmt-studio-5g6g

It is an open-source 5G SA core (MMT Studio Core) built on Open5GS, intended for private 5G lab and testbed deployments.

Checked against CONTRIBUTING.md: single entry, placed in the correct category (5G core), sentence-case description ending with a period, and an HTTPS link to a public repo.