### PR TITLE
Add SCP03 Helper to SIM/USIM Tools & Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ For research and debugging:
 - [osmo-subscr-impex](https://gitea.osmocom.org/sim-card/osmo-subscr-impex) - Osmocom subscriber authentication data importer/exporter. Hosted on **Osmocom Gitea**.
 - [osmo-ccid-firmware](https://gitea.osmocom.org/sim-card/osmo-ccid-firmware) - USB CCID firmware project for (currently only) sysmoOCTSIM. Hosted on **Osmocom Gitea**.
 - [osmo-sim-auth](https://gitea.osmocom.org/sim-card/osmo-sim-auth) - A command line tool for (U)SIM authentication. Hosted on **Osmocom Gitea**.
+- [SCP03 Helper](https://ambisecure.ambimat.com/resources/tools/scp03-helper/) - Browser-based calculator for GlobalPlatform SCP03 session keys (S-ENC/S-MAC/S-RMAC) and host/card cryptograms, using AES-CMAC and the SP 800-108 KDF. Runs client-side as a learning and debugging aid for use with test keys, not production tooling.
 
 ### eSIM / eUICC
 


### PR DESCRIPTION
Adds one entry to **SIM Cards → SIM/USIM Tools & Hardware**, next to the existing GlobalPlatform tooling (GlobalPlatformPro, apdu4j, simshell).

```
- [SCP03 Helper](https://ambisecure.ambimat.com/resources/tools/scp03-helper/) - Browser-based calculator for GlobalPlatform SCP03 session keys (S-ENC/S-MAC/S-RMAC) and host/card cryptograms, using AES-CMAC and the SP 800-108 KDF. Runs client-side as a learning and debugging aid for use with test keys, not production tooling.
```

### What it does

Given the two static base keys (K-ENC, K-MAC) and the host and card challenges, it derives the three SCP03 session keys and both cryptograms as specified in GlobalPlatform Amendment D, showing the intermediate values. The typical use is working out why a card rejected an `EXTERNAL AUTHENTICATE`, or checking your own KDF against a reference.

### Notes against the quality checklist

- **Works, and the crypto is checkable.** Derivation is NIST SP 800-108 counter mode with AES-CMAC as the PRF. Web Crypto has no CMAC, so the tool implements RFC 4493 over `crypto.subtle` AES-CBC; that implementation reproduces the published RFC 4493 AES-128 test vectors, so the primitive underneath the KDF can be verified rather than taken on trust.
- **Accessible** — no login, no paywall, no signup.
- **Not a duplicate.** YggdraSIM lists SCP03 among its features, but it is a Python toolkit for SIM/eSIM provisioning; this is a single-page derivation calculator for the handshake maths. Different job, and useful without a Python environment or a card present.
- **Educational scope, and scoped honestly.** The page states plainly that it is a teaching aid, that there is no channel state, command counter, or key wrapping, and that it is a calculator for the derivation rather than a secure channel. It tells users not to paste production keys, and everything runs locally with nothing uploaded.
- It also documents the mistakes people actually hit: swapping the host and card cryptograms (`0x01` vs `0x00`), reversing the `host || card` context order, and mismatched K-ENC/K-MAC lengths.

No affiliation with or endorsement by GlobalPlatform is claimed. Sentence case, ends with a period, HTTPS, no trailing whitespace; not a GitHub/GitLab link, so no `[YYYY-MM]` freshness tag, matching the other non-repo entries in the section.