### PR TITLE
Add ant-javacard to SIM/USIM tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ For research and debugging:
 - [SIMTrace2](https://osmocom.org/projects/simtrace2) - Hardware device + firmware to trace communication between phone and SIM card. Supports card-side emulation. Works with [ngff-cardem](https://osmocom.org/projects/ngff-cardem/wiki).
 - [SIMTester](https://github.com/srlabs/SIMTester) `[2023-02]` - Assess SIM card security: cryptanalytic attack surface and application attack surface.
 - [GlobalPlatformPro](https://github.com/martinpaljak/GlobalPlatformPro) `[2026-09]` - CLI tool to load and manage applets on JavaCards, by Martin Paljak.
+- [ant-javacard](https://github.com/martinpaljak/ant-javacard) `[2026-09]` - Ant task to build JavaCard applets (JavaCard 2.1.1 to 3.2.0). Used to build SIM Toolkit applets.
 - [ARA-M Applet](https://github.com/bertrandmartel/aram-applet) `[2018-02]` - ARA-M implementation for JavaCards by Bertrand Martel.
 - ⚠️ [HelloSTK2](https://github.com/mrlnc/HelloSTK2) `[2025-01]` - Guide to build and install SIM-Toolkit applets.
 - [SUPI with pysim](https://gist.github.com/mrlnc/01d6300f1904f154d969ff205136b753) - Notes on enabling SUPI with pysim.


### PR DESCRIPTION
Adds [ant-javacard](https://github.com/martinpaljak/ant-javacard) to SIM/USIM Tools & Hardware. It builds the JavaCard applets that the section already covers (HelloSTK2, ARA-M Applet, sim-toolkit-refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)